### PR TITLE
pref: skip filtering for specific HTML

### DIFF
--- a/console/src/editor/markdown-edited.ts
+++ b/console/src/editor/markdown-edited.ts
@@ -19,6 +19,25 @@ const turndownService = new TurndownService({
   bulletListMarker: "-",
   codeBlockStyle: "fenced",
 });
+turndownService.keep([
+  "audio",
+  "br",
+  "button",
+  "canvas",
+  "cite",
+  "datalist",
+  "div",
+  "figure",
+  "iframe",
+  "p",
+  "script",
+  "source",
+  "span",
+  "style",
+  "summary",
+  "textarea",
+  "video",
+]);
 
 declare module "@tiptap/core" {
   interface Commands<ReturnType> {

--- a/console/src/editor/markdown-edited.ts
+++ b/console/src/editor/markdown-edited.ts
@@ -21,7 +21,6 @@ const turndownService = new TurndownService({
 });
 turndownService.keep([
   "audio",
-  "br",
   "button",
   "canvas",
   "cite",
@@ -29,7 +28,6 @@ turndownService.keep([
   "div",
   "figure",
   "iframe",
-  "p",
   "script",
   "source",
   "span",


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement

#### What this PR does / why we need it:

将为 HTML 转为 Markdown 时，允许不对特定的 HTML 进行过滤。

#### Which issue(s) this PR fixes:

Fixes #4 

#### Does this PR introduce a user-facing change?
```release-note
允许在 Markdown 块中包含特定的 HTML 元素。
```
