### PR TITLE
fix: resolve markdown editing block parsing error

### DIFF
--- a/console/src/editor/markdown-edited.ts
+++ b/console/src/editor/markdown-edited.ts
@@ -18,6 +18,9 @@ const turndownService = new TurndownService({
   hr: "---",
   bulletListMarker: "-",
   codeBlockStyle: "fenced",
+  blankReplacement: function (content, node) {
+    return (node as HTMLElement).outerHTML;
+  },
 });
 
 declare module "@tiptap/core" {
@@ -177,7 +180,10 @@ const MarkdownEdited = Node.create({
             return Fragment.empty;
           }
           // html covert to markdown
-          const markdown = turndownService.turndown(htmlNode.innerHTML);
+          let markdown = turndownService.turndown(htmlNode.innerHTML);
+          if (!markdown) {
+            markdown = "<br>";
+          }
           const textNode = schema.text(markdown);
           return Fragment.from(textNode);
         },

--- a/console/src/editor/markdown-edited.ts
+++ b/console/src/editor/markdown-edited.ts
@@ -19,7 +19,10 @@ const turndownService = new TurndownService({
   bulletListMarker: "-",
   codeBlockStyle: "fenced",
   blankReplacement: function (content, node) {
-    return (node as HTMLElement).outerHTML;
+    if (node instanceof HTMLElement) {
+      return node.outerHTML;
+    }
+    return content;
   },
 });
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

解决 HTML 转 markdown 时可能转换为空串进而导致富文本编辑器报错的问题。
修改之后的规则：
1. 当输入一个空标签，例如 `<p></p>`，则直接会返回此标签。
2. 当输入空字符或者 `<br>`，统一回显为 `<br>`
 
#### How to test it?

添加 Markdown 编辑块，添加空串或者空标签，查看是否会报错。

#### Which issue(s) this PR fixes:

Fixes #5 

#### Does this PR introduce a user-facing change?
```release-note
解决 Markdown 编辑块空内容导致的报错问题。
```
