### PR TITLE
feat: add heading id generate feature for markdown block

### DIFF
--- a/console/package.json
+++ b/console/package.json
@@ -18,6 +18,7 @@
     "@halo-dev/console-shared": "^2.7.0",
     "@lezer/highlight": "1.1.6",
     "marked": "^9.1.2",
+    "marked-gfm-heading-id": "^3.1.2",
     "turndown": "^7.1.2",
     "turndown-plugin-gfm": "^1.0.2",
     "vue": "^3.3.4"

--- a/console/pnpm-lock.yaml
+++ b/console/pnpm-lock.yaml
@@ -38,6 +38,9 @@ dependencies:
   marked:
     specifier: ^9.1.2
     version: 9.1.2
+  marked-gfm-heading-id:
+    specifier: ^3.1.2
+    version: 3.1.2(marked@9.1.2)
   turndown:
     specifier: ^7.1.2
     version: 7.1.2
@@ -3121,6 +3124,10 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
+  /github-slugger@2.0.0:
+    resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
+    dev: false
+
   /glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -3686,6 +3693,15 @@ packages:
       mdurl: 1.0.1
       uc.micro: 1.0.6
     dev: true
+
+  /marked-gfm-heading-id@3.1.2(marked@9.1.2):
+    resolution: {integrity: sha512-SdIZvhNxDgndFkDa2WRcFP4ahYm6k6hoHdTCN+fD7HRiI/R3Eimcw/Yl7ikQ+0KUuDpi75NnYQiThZnZsNr9Dg==}
+    peerDependencies:
+      marked: '>=4 <12'
+    dependencies:
+      github-slugger: 2.0.0
+      marked: 9.1.2
+    dev: false
 
   /marked@9.1.2:
     resolution: {integrity: sha512-qoKMJqK0w6vkLk8+KnKZAH6neUZSNaQqVZ/h2yZ9S7CbLuFHyS2viB0jnqcWF9UKjwsAbMrQtnQhdmdvOVOw9w==}

--- a/console/src/editor/markdown-edited.ts
+++ b/console/src/editor/markdown-edited.ts
@@ -5,7 +5,7 @@ import MdiLanguageMarkdown from "~icons/mdi/language-markdown";
 import { CodeMirrorView } from "./code-mirror-view";
 import { Fragment } from "@tiptap/pm/model";
 import { markdown } from "@codemirror/lang-markdown";
-import { marked } from "marked";
+import marked from "@/utils/markdown";
 import TurndownService from "turndown";
 import { gfm } from "turndown-plugin-gfm";
 import { ToolboxItem } from "@halo-dev/richtext-editor";

--- a/console/src/utils/markdown.ts
+++ b/console/src/utils/markdown.ts
@@ -1,0 +1,6 @@
+import { marked } from "marked";
+import { gfmHeadingId } from "marked-gfm-heading-id";
+
+marked.use(gfmHeadingId());
+
+export default marked;


### PR DESCRIPTION
为 Markdown 块的 heading 增加 id。需要注意的是，这个 id 暂时无法与默认编辑器的 id 共享，需要使用者自行避免重复。

/kind feature
Fixes #11 

```release-note
为 Markdown 块的 heading 增加 id
```