### PR TITLE
fix: incorrect homepage in plugin.yaml

### DIFF
--- a/src/main/resources/plugin.yaml
+++ b/src/main/resources/plugin.yaml
@@ -9,7 +9,9 @@ spec:
     name: Halo
     website: https://github.com/halo-dev
   logo: logo.svg
-  homepage: https://github.com/halo-dev/plugin-hybrid-edit-block
+  homepage: https://www.halo.run/store/apps/app-NgHnY
+  issues: https://github.com/halo-sigs/plugin-hybrid-edit-block/issues
+  repo: https://github.com/halo-sigs/plugin-hybrid-edit-block
   displayName: "Markdown / HTML 内容块"
   description: "为默认富文本编辑器提供编写 Markdown / HTML 的内容块扩展"
   license:


### PR DESCRIPTION
### What this PR does?
修复不正确的 homepage 链接

```release-note
None
```