### PR TITLE
chore: cleanup deprecated constructor for base plugin

### DIFF
--- a/src/main/java/run/halo/editor/HybridEditBlockPlugin.java
+++ b/src/main/java/run/halo/editor/HybridEditBlockPlugin.java
@@ -1,23 +1,14 @@
 package run.halo.editor;
 
-import org.pf4j.PluginWrapper;
 import org.springframework.stereotype.Component;
+
 import run.halo.app.plugin.BasePlugin;
+import run.halo.app.plugin.PluginContext;
 
 @Component
 public class HybridEditBlockPlugin extends BasePlugin {
 
-    public HybridEditBlockPlugin(PluginWrapper wrapper) {
-        super(wrapper);
-    }
-
-    @Override
-    public void start() {
-        System.out.println("插件启动成功！");
-    }
-
-    @Override
-    public void stop() {
-        System.out.println("插件停止！");
+    public HybridEditBlockPlugin(PluginContext context) {
+        super(context);
     }
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/area plugin
/milestone 2.17.x

#### What this PR does / why we need it:
移除 BasePlugin 中已经过时的构造方法

在 2.6.1 版本中将 `BasePlugin(PluginWrapper wrapper)` 标记为过时并使用 `BasePlugin(PluginContext pluginContext)` 代替，现在已经过了很多版本，是时候移除它了。

#### Does this PR introduce a user-facing change?
```release-note
开发者相关：移除 BasePlugin 中已经过时的构造方法
```
