### PR TITLE
feat: add markdown table shortcuts

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -18,6 +18,7 @@
     "@halo-dev/components": "^2.22.0",
     "@halo-dev/ui-shared": "^2.22.0",
     "@lezer/highlight": "1.1.6",
+    "@susisu/mte-kernel": "^2.1.1",
     "marked": "^9.1.2",
     "marked-gfm-heading-id": "^3.1.2",
     "turndown": "^7.1.2",

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       '@lezer/highlight':
         specifier: 1.1.6
         version: 1.1.6
+      '@susisu/mte-kernel':
+        specifier: ^2.1.1
+        version: 2.1.1
       marked:
         specifier: ^9.1.2
         version: 9.1.6
@@ -911,6 +914,9 @@ packages:
 
   '@rushstack/eslint-patch@1.15.0':
     resolution: {integrity: sha512-ojSshQPKwVvSMR8yT2L/QtUkV5SXi/IfDiJ4/8d6UbTPjiHVmxZzUAzGD8Tzks1b9+qQkZa0isUOvYObedITaw==}
+
+  '@susisu/mte-kernel@2.1.1':
+    resolution: {integrity: sha512-i2lucPD0BOUNIY6P0MGIUbJ/piV8iNzwB8QU1fdkRLls85rq8NJa75oeZVWo2PLrUWjN64+3oD85kZFsx3ovyA==}
 
   '@swc/helpers@0.5.18':
     resolution: {integrity: sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==}
@@ -2310,6 +2316,10 @@ packages:
 
   mdurl@2.0.0:
     resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
+
+  meaw@5.0.0:
+    resolution: {integrity: sha512-yaK9Pnj6JrLcQGEqDUS0WGUEiaFg9Q215isi8mzcDVOjeGr5oS863hu+/ZS49g+azKPo5Wbpk3tgkP2+YOyZZw==}
+    engines: {node: '>=10.0.0'}
 
   memorystream@0.3.1:
     resolution: {integrity: sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==}
@@ -4234,6 +4244,10 @@ snapshots:
 
   '@rushstack/eslint-patch@1.15.0': {}
 
+  '@susisu/mte-kernel@2.1.1':
+    dependencies:
+      meaw: 5.0.0
+
   '@swc/helpers@0.5.18':
     dependencies:
       tslib: 2.8.1
@@ -5836,6 +5850,8 @@ snapshots:
   mdn-data@2.12.2: {}
 
   mdurl@2.0.0: {}
+
+  meaw@5.0.0: {}
 
   memorystream@0.3.1: {}
 

--- a/ui/src/editor/CodeMirrorView.vue
+++ b/ui/src/editor/CodeMirrorView.vue
@@ -34,7 +34,6 @@ import {
 } from "@halo-dev/richtext-editor";
 import MingcuteRightSmallFill from "~icons/mingcute/right-small-fill";
 import type { Line, SelectionRange } from "@codemirror/state";
-
 const props = defineProps(nodeViewProps);
 
 const editorContainerRef = ref<HTMLElement>();
@@ -64,7 +63,6 @@ const blockLabel = computed<string>(() => {
       return blockType.value;
   }
 });
-
 let cm: CodeMirror | undefined;
 let updating = false;
 let previewRenderer: PreviewRenderer | undefined;

--- a/ui/src/editor/markdown-edited.ts
+++ b/ui/src/editor/markdown-edited.ts
@@ -20,6 +20,7 @@ import TurndownService from "turndown";
 import { gfm } from "turndown-plugin-gfm";
 import MdiDeleteForeverOutline from "~icons/mdi/delete-forever-outline?color=red";
 import { deleteNode } from "../utils/delete-node";
+import { markdownTableExtension } from "./markdown-table";
 const temporaryDocument = document.implementation.createHTMLDocument();
 const turndownService = new TurndownService({
   headingStyle: "atx",
@@ -93,7 +94,7 @@ const MarkdownEdited = Node.create<ExtensionOptions>({
         class: "markdown-edited",
       },
       blockType: "markdown",
-      extensions: [markdown()],
+      extensions: [markdown(), markdownTableExtension()],
       getCommandMenuItems() {
         return {
           priority: 82,

--- a/ui/src/editor/markdown-table.ts
+++ b/ui/src/editor/markdown-table.ts
@@ -1,12 +1,84 @@
 import { EditorSelection, Prec, type Extension } from "@codemirror/state";
 import { keymap, type EditorView, type KeyBinding } from "@codemirror/view";
-import {
+import * as mteKernel from "@susisu/mte-kernel";
+
+type AlignmentValue = string;
+
+interface TableEditorOptions {
+  leftMarginChars?: Set<string>;
+  formatType?: string;
+  minDelimiterWidth?: number;
+  defaultAlignment?: string;
+  headerAlignment?: string;
+  smartCursor?: boolean;
+}
+
+type ResolvedTableEditorOptions = Required<TableEditorOptions>;
+
+interface TablePoint {
+  row: number;
+  column: number;
+}
+
+interface TableRange {
+  start: TablePoint;
+  end: TablePoint;
+}
+
+interface MteTextEditor {
+  getCursorPosition(): TablePoint;
+  setCursorPosition(pos: TablePoint): void;
+  setSelectionRange(range: TableRange): void;
+  getLastRow(): number;
+  acceptsTableEdit(row: number): boolean;
+  getLine(row: number): string;
+  insertLine(row: number, line: string): void;
+  deleteLine(row: number): void;
+  replaceLines(startRow: number, endRow: number, lines: Array<string>): void;
+  transact(func: () => void): void;
+}
+
+interface MteTableEditor {
+  cursorIsInTable(options: ResolvedTableEditorOptions): boolean;
+  format(options: ResolvedTableEditorOptions): void;
+  formatAll(options: ResolvedTableEditorOptions): void;
+  escape(options: ResolvedTableEditorOptions): void;
+  moveFocus(
+    rowOffset: number,
+    columnOffset: number,
+    options: ResolvedTableEditorOptions
+  ): void;
+  alignColumn(
+    alignment: AlignmentValue,
+    options: ResolvedTableEditorOptions
+  ): void;
+  nextCell(options: ResolvedTableEditorOptions): void;
+  previousCell(options: ResolvedTableEditorOptions): void;
+  nextRow(options: ResolvedTableEditorOptions): void;
+  insertRow(options: ResolvedTableEditorOptions): void;
+  deleteRow(options: ResolvedTableEditorOptions): void;
+  moveRow(offset: number, options: ResolvedTableEditorOptions): void;
+  insertColumn(options: ResolvedTableEditorOptions): void;
+  deleteColumn(options: ResolvedTableEditorOptions): void;
+  moveColumn(offset: number, options: ResolvedTableEditorOptions): void;
+}
+
+const {
   Alignment,
   Point,
-  Range,
   TableEditor,
-  options as createTableOptions,
-} from "@susisu/mte-kernel";
+  options: createTableOptions,
+} = mteKernel as {
+  Alignment: {
+    readonly NONE: AlignmentValue;
+    readonly LEFT: AlignmentValue;
+    readonly RIGHT: AlignmentValue;
+    readonly CENTER: AlignmentValue;
+  };
+  Point: new (row: number, column: number) => TablePoint;
+  TableEditor: new (textEditor: MteTextEditor) => MteTableEditor;
+  options: (options: TableEditorOptions) => ResolvedTableEditorOptions;
+};
 
 export type MarkdownTableCommandName =
   | "format"
@@ -40,7 +112,7 @@ const COMMANDS: Record<
   MarkdownTableCommandName,
   {
     requiresCursorInTable: boolean;
-    run: (tableEditor: TableEditor) => void;
+    run: (tableEditor: MteTableEditor) => void;
   }
 > = {
   format: {
@@ -137,14 +209,14 @@ const COMMANDS: Record<
   },
 };
 
-class CodeMirrorTableTextEditor {
+class CodeMirrorTableTextEditor implements MteTextEditor {
   private transactionDepth = 0;
   private workingLines: string[] | null = null;
   private workingSelection: { anchor: number; head: number } | null = null;
 
   constructor(private readonly view: EditorView) {}
 
-  getCursorPosition(): Point {
+  getCursorPosition(): TablePoint {
     const lines = this.getLines();
     const selection = this.workingSelection ?? {
       anchor: this.view.state.selection.main.anchor,
@@ -153,7 +225,7 @@ class CodeMirrorTableTextEditor {
     return offsetToPoint(lines, selection.head);
   }
 
-  setCursorPosition(pos: Point): void {
+  setCursorPosition(pos: TablePoint): void {
     if (this.transactionDepth === 0) {
       this.transact(() => this.setCursorPosition(pos));
       return;
@@ -163,7 +235,7 @@ class CodeMirrorTableTextEditor {
     this.workingSelection = { anchor, head: anchor };
   }
 
-  setSelectionRange(range: Range): void {
+  setSelectionRange(range: TableRange): void {
     if (this.transactionDepth === 0) {
       this.transact(() => this.setSelectionRange(range));
       return;
@@ -313,7 +385,7 @@ const normalizeLines = (lines: string[]): string[] => {
   return lines.length > 0 ? lines : [""];
 };
 
-const pointToOffset = (lines: string[], point: Point): number => {
+const pointToOffset = (lines: string[], point: TablePoint): number => {
   const row = clamp(point.row, 0, lines.length - 1);
   const column = clamp(point.column, 0, lines[row].length);
   let offset = 0;
@@ -325,7 +397,7 @@ const pointToOffset = (lines: string[], point: Point): number => {
   return offset + column;
 };
 
-const offsetToPoint = (lines: string[], offset: number): Point => {
+const offsetToPoint = (lines: string[], offset: number): TablePoint => {
   let remaining = clamp(offset, 0, lines.join("\n").length);
 
   for (let row = 0; row < lines.length; row += 1) {
@@ -453,73 +525,3 @@ const markdownTableKeybindings: KeyBinding[] = [
 export const markdownTableExtension = (): Extension => {
   return Prec.highest(keymap.of(markdownTableKeybindings));
 };
-
-declare module "@susisu/mte-kernel" {
-  export interface ITextEditor {
-    getCursorPosition(): Point;
-    setCursorPosition(pos: Point): void;
-    setSelectionRange(range: Range): void;
-    getLastRow(): number;
-    acceptsTableEdit(row: number): boolean;
-    getLine(row: number): string;
-    insertLine(row: number, line: string): void;
-    deleteLine(row: number): void;
-    replaceLines(startRow: number, endRow: number, lines: Array<string>): void;
-    transact(func: () => void): void;
-  }
-
-  export class Point {
-    constructor(row: number, column: number);
-    readonly row: number;
-    readonly column: number;
-  }
-
-  export class Range {
-    constructor(start: Point, end: Point);
-    readonly start: Point;
-    readonly end: Point;
-  }
-
-  export const Alignment: {
-    readonly NONE: string;
-    readonly LEFT: string;
-    readonly RIGHT: string;
-    readonly CENTER: string;
-  };
-
-  export interface TableEditorOptions {
-    leftMarginChars?: Set<string>;
-    formatType?: string;
-    minDelimiterWidth?: number;
-    defaultAlignment?: string;
-    headerAlignment?: string;
-    smartCursor?: boolean;
-  }
-
-  export function options(
-    options: TableEditorOptions
-  ): Required<TableEditorOptions>;
-
-  export class TableEditor {
-    constructor(textEditor: ITextEditor);
-    cursorIsInTable(options: Required<TableEditorOptions>): boolean;
-    format(options: Required<TableEditorOptions>): void;
-    formatAll(options: Required<TableEditorOptions>): void;
-    escape(options: Required<TableEditorOptions>): void;
-    moveFocus(
-      rowOffset: number,
-      columnOffset: number,
-      options: Required<TableEditorOptions>
-    ): void;
-    alignColumn(alignment: string, options: Required<TableEditorOptions>): void;
-    nextCell(options: Required<TableEditorOptions>): void;
-    previousCell(options: Required<TableEditorOptions>): void;
-    nextRow(options: Required<TableEditorOptions>): void;
-    insertRow(options: Required<TableEditorOptions>): void;
-    deleteRow(options: Required<TableEditorOptions>): void;
-    moveRow(offset: number, options: Required<TableEditorOptions>): void;
-    insertColumn(options: Required<TableEditorOptions>): void;
-    deleteColumn(options: Required<TableEditorOptions>): void;
-    moveColumn(offset: number, options: Required<TableEditorOptions>): void;
-  }
-}

--- a/ui/src/editor/markdown-table.ts
+++ b/ui/src/editor/markdown-table.ts
@@ -1,0 +1,525 @@
+import { EditorSelection, Prec, type Extension } from "@codemirror/state";
+import { keymap, type EditorView, type KeyBinding } from "@codemirror/view";
+import {
+  Alignment,
+  Point,
+  Range,
+  TableEditor,
+  options as createTableOptions,
+} from "@susisu/mte-kernel";
+
+export type MarkdownTableCommandName =
+  | "format"
+  | "formatAll"
+  | "escape"
+  | "nextCell"
+  | "previousCell"
+  | "nextRow"
+  | "moveLeft"
+  | "moveRight"
+  | "moveUp"
+  | "moveDown"
+  | "insertRow"
+  | "deleteRow"
+  | "moveRowUp"
+  | "moveRowDown"
+  | "insertColumn"
+  | "deleteColumn"
+  | "moveColumnLeft"
+  | "moveColumnRight"
+  | "alignNone"
+  | "alignLeft"
+  | "alignCenter"
+  | "alignRight";
+
+const TABLE_OPTIONS = createTableOptions({
+  smartCursor: true,
+});
+
+const COMMANDS: Record<
+  MarkdownTableCommandName,
+  {
+    requiresCursorInTable: boolean;
+    run: (tableEditor: TableEditor) => void;
+  }
+> = {
+  format: {
+    requiresCursorInTable: true,
+    run: (tableEditor) => tableEditor.format(TABLE_OPTIONS),
+  },
+  formatAll: {
+    requiresCursorInTable: false,
+    run: (tableEditor) => tableEditor.formatAll(TABLE_OPTIONS),
+  },
+  escape: {
+    requiresCursorInTable: true,
+    run: (tableEditor) => tableEditor.escape(TABLE_OPTIONS),
+  },
+  nextCell: {
+    requiresCursorInTable: true,
+    run: (tableEditor) => tableEditor.nextCell(TABLE_OPTIONS),
+  },
+  previousCell: {
+    requiresCursorInTable: true,
+    run: (tableEditor) => tableEditor.previousCell(TABLE_OPTIONS),
+  },
+  nextRow: {
+    requiresCursorInTable: true,
+    run: (tableEditor) => tableEditor.nextRow(TABLE_OPTIONS),
+  },
+  moveLeft: {
+    requiresCursorInTable: true,
+    run: (tableEditor) => tableEditor.moveFocus(0, -1, TABLE_OPTIONS),
+  },
+  moveRight: {
+    requiresCursorInTable: true,
+    run: (tableEditor) => tableEditor.moveFocus(0, 1, TABLE_OPTIONS),
+  },
+  moveUp: {
+    requiresCursorInTable: true,
+    run: (tableEditor) => tableEditor.moveFocus(-1, 0, TABLE_OPTIONS),
+  },
+  moveDown: {
+    requiresCursorInTable: true,
+    run: (tableEditor) => tableEditor.moveFocus(1, 0, TABLE_OPTIONS),
+  },
+  insertRow: {
+    requiresCursorInTable: true,
+    run: (tableEditor) => tableEditor.insertRow(TABLE_OPTIONS),
+  },
+  deleteRow: {
+    requiresCursorInTable: true,
+    run: (tableEditor) => tableEditor.deleteRow(TABLE_OPTIONS),
+  },
+  moveRowUp: {
+    requiresCursorInTable: true,
+    run: (tableEditor) => tableEditor.moveRow(-1, TABLE_OPTIONS),
+  },
+  moveRowDown: {
+    requiresCursorInTable: true,
+    run: (tableEditor) => tableEditor.moveRow(1, TABLE_OPTIONS),
+  },
+  insertColumn: {
+    requiresCursorInTable: true,
+    run: (tableEditor) => tableEditor.insertColumn(TABLE_OPTIONS),
+  },
+  deleteColumn: {
+    requiresCursorInTable: true,
+    run: (tableEditor) => tableEditor.deleteColumn(TABLE_OPTIONS),
+  },
+  moveColumnLeft: {
+    requiresCursorInTable: true,
+    run: (tableEditor) => tableEditor.moveColumn(-1, TABLE_OPTIONS),
+  },
+  moveColumnRight: {
+    requiresCursorInTable: true,
+    run: (tableEditor) => tableEditor.moveColumn(1, TABLE_OPTIONS),
+  },
+  alignNone: {
+    requiresCursorInTable: true,
+    run: (tableEditor) =>
+      tableEditor.alignColumn(Alignment.NONE, TABLE_OPTIONS),
+  },
+  alignLeft: {
+    requiresCursorInTable: true,
+    run: (tableEditor) =>
+      tableEditor.alignColumn(Alignment.LEFT, TABLE_OPTIONS),
+  },
+  alignCenter: {
+    requiresCursorInTable: true,
+    run: (tableEditor) =>
+      tableEditor.alignColumn(Alignment.CENTER, TABLE_OPTIONS),
+  },
+  alignRight: {
+    requiresCursorInTable: true,
+    run: (tableEditor) =>
+      tableEditor.alignColumn(Alignment.RIGHT, TABLE_OPTIONS),
+  },
+};
+
+class CodeMirrorTableTextEditor {
+  private transactionDepth = 0;
+  private workingLines: string[] | null = null;
+  private workingSelection: { anchor: number; head: number } | null = null;
+
+  constructor(private readonly view: EditorView) {}
+
+  getCursorPosition(): Point {
+    const lines = this.getLines();
+    const selection = this.workingSelection ?? {
+      anchor: this.view.state.selection.main.anchor,
+      head: this.view.state.selection.main.head,
+    };
+    return offsetToPoint(lines, selection.head);
+  }
+
+  setCursorPosition(pos: Point): void {
+    if (this.transactionDepth === 0) {
+      this.transact(() => this.setCursorPosition(pos));
+      return;
+    }
+
+    const anchor = pointToOffset(this.getMutableLines(), pos);
+    this.workingSelection = { anchor, head: anchor };
+  }
+
+  setSelectionRange(range: Range): void {
+    if (this.transactionDepth === 0) {
+      this.transact(() => this.setSelectionRange(range));
+      return;
+    }
+
+    this.workingSelection = {
+      anchor: pointToOffset(this.getMutableLines(), range.start),
+      head: pointToOffset(this.getMutableLines(), range.end),
+    };
+  }
+
+  getLastRow(): number {
+    return this.getLines().length - 1;
+  }
+
+  acceptsTableEdit(row: number): boolean {
+    return row >= 0 && row <= this.getLastRow();
+  }
+
+  getLine(row: number): string {
+    return this.getLines()[row] ?? "";
+  }
+
+  insertLine(row: number, line: string): void {
+    if (this.transactionDepth === 0) {
+      this.transact(() => this.insertLine(row, line));
+      return;
+    }
+
+    const lines = this.getMutableLines();
+    const targetRow = clamp(row, 0, lines.length);
+    lines.splice(targetRow, 0, line);
+  }
+
+  deleteLine(row: number): void {
+    if (this.transactionDepth === 0) {
+      this.transact(() => this.deleteLine(row));
+      return;
+    }
+
+    const lines = this.getMutableLines();
+    if (row < 0 || row > lines.length - 1) {
+      return;
+    }
+    lines.splice(row, 1);
+    if (lines.length === 0) {
+      lines.push("");
+    }
+  }
+
+  replaceLines(startRow: number, endRow: number, lines: Array<string>): void {
+    if (this.transactionDepth === 0) {
+      this.transact(() => this.replaceLines(startRow, endRow, lines));
+      return;
+    }
+
+    const mutableLines = this.getMutableLines();
+    const start = clamp(startRow, 0, mutableLines.length);
+    const end = clamp(endRow, start, mutableLines.length);
+    mutableLines.splice(start, end - start, ...lines);
+    if (mutableLines.length === 0) {
+      mutableLines.push("");
+    }
+  }
+
+  transact(func: () => void): void {
+    const isRootTransaction = this.transactionDepth === 0;
+    if (isRootTransaction) {
+      this.workingLines = [...this.getLines()];
+      this.workingSelection = {
+        anchor: this.view.state.selection.main.anchor,
+        head: this.view.state.selection.main.head,
+      };
+    }
+
+    this.transactionDepth += 1;
+
+    try {
+      func();
+    } finally {
+      this.transactionDepth -= 1;
+      if (isRootTransaction) {
+        this.commit();
+      }
+    }
+  }
+
+  private getLines(): string[] {
+    if (this.workingLines) {
+      return this.workingLines;
+    }
+    return normalizeLines(this.view.state.doc.toString().split("\n"));
+  }
+
+  private getMutableLines(): string[] {
+    if (!this.workingLines) {
+      this.workingLines = [...this.getLines()];
+    }
+    return this.workingLines;
+  }
+
+  private commit(): void {
+    const previousDoc = this.view.state.doc.toString();
+    const nextLines = normalizeLines(
+      this.workingLines ?? previousDoc.split("\n")
+    );
+    const nextDoc = nextLines.join("\n");
+    const currentSelection = this.view.state.selection.main;
+    const nextSelection = this.workingSelection ?? {
+      anchor: currentSelection.anchor,
+      head: currentSelection.head,
+    };
+    const anchor = clamp(nextSelection.anchor, 0, nextDoc.length);
+    const head = clamp(nextSelection.head, 0, nextDoc.length);
+
+    const docChanged = nextDoc !== previousDoc;
+    const selectionChanged =
+      anchor !== currentSelection.anchor || head !== currentSelection.head;
+
+    if (docChanged || selectionChanged) {
+      this.view.dispatch({
+        ...(docChanged
+          ? {
+              changes: {
+                from: 0,
+                to: previousDoc.length,
+                insert: nextDoc,
+              },
+            }
+          : {}),
+        selection: EditorSelection.create([
+          EditorSelection.range(anchor, head),
+        ]),
+      });
+    }
+
+    this.workingLines = null;
+    this.workingSelection = null;
+  }
+}
+
+const clamp = (value: number, min: number, max: number): number => {
+  return Math.min(Math.max(value, min), max);
+};
+
+const normalizeLines = (lines: string[]): string[] => {
+  return lines.length > 0 ? lines : [""];
+};
+
+const pointToOffset = (lines: string[], point: Point): number => {
+  const row = clamp(point.row, 0, lines.length - 1);
+  const column = clamp(point.column, 0, lines[row].length);
+  let offset = 0;
+
+  for (let index = 0; index < row; index += 1) {
+    offset += lines[index].length + 1;
+  }
+
+  return offset + column;
+};
+
+const offsetToPoint = (lines: string[], offset: number): Point => {
+  let remaining = clamp(offset, 0, lines.join("\n").length);
+
+  for (let row = 0; row < lines.length; row += 1) {
+    const lineLength = lines[row].length;
+    if (remaining <= lineLength) {
+      return new Point(row, remaining);
+    }
+    remaining -= lineLength + 1;
+  }
+
+  const lastRow = lines.length - 1;
+  return new Point(lastRow, lines[lastRow].length);
+};
+
+const executeMarkdownTableCommand = (
+  view: EditorView,
+  commandName: MarkdownTableCommandName,
+  requireCurrentTable = true
+): boolean => {
+  const command = COMMANDS[commandName];
+  const tableTextEditor = new CodeMirrorTableTextEditor(view);
+  const tableEditor = new TableEditor(tableTextEditor);
+  const mustBeInTable = requireCurrentTable && command.requiresCursorInTable;
+
+  if (mustBeInTable && !tableEditor.cursorIsInTable(TABLE_OPTIONS)) {
+    return false;
+  }
+
+  command.run(tableEditor);
+  view.focus();
+  return true;
+};
+
+const markdownTableKeybindings: KeyBinding[] = [
+  {
+    key: "Tab",
+    run: (view) => executeMarkdownTableCommand(view, "nextCell"),
+  },
+  {
+    key: "Shift-Tab",
+    run: (view) => executeMarkdownTableCommand(view, "previousCell"),
+  },
+  {
+    key: "Enter",
+    run: (view) => executeMarkdownTableCommand(view, "nextRow"),
+  },
+  {
+    key: "Escape",
+    run: (view) => executeMarkdownTableCommand(view, "escape"),
+  },
+  {
+    key: "Mod-Alt-f",
+    run: (view) => executeMarkdownTableCommand(view, "format"),
+  },
+  {
+    key: "Mod-Alt-Shift-f",
+    run: (view) => executeMarkdownTableCommand(view, "formatAll", false),
+  },
+  {
+    key: "Mod-ArrowLeft",
+    run: (view) => executeMarkdownTableCommand(view, "moveLeft"),
+  },
+  {
+    key: "Mod-ArrowRight",
+    run: (view) => executeMarkdownTableCommand(view, "moveRight"),
+  },
+  {
+    key: "Mod-ArrowUp",
+    run: (view) => executeMarkdownTableCommand(view, "moveUp"),
+  },
+  {
+    key: "Mod-ArrowDown",
+    run: (view) => executeMarkdownTableCommand(view, "moveDown"),
+  },
+  {
+    key: "Shift-Mod-ArrowLeft",
+    run: (view) => executeMarkdownTableCommand(view, "alignLeft"),
+  },
+  {
+    key: "Shift-Mod-ArrowRight",
+    run: (view) => executeMarkdownTableCommand(view, "alignRight"),
+  },
+  {
+    key: "Shift-Mod-ArrowUp",
+    run: (view) => executeMarkdownTableCommand(view, "alignCenter"),
+  },
+  {
+    key: "Shift-Mod-ArrowDown",
+    run: (view) => executeMarkdownTableCommand(view, "alignNone"),
+  },
+  {
+    key: "Mod-Alt-ArrowUp",
+    run: (view) => executeMarkdownTableCommand(view, "moveRowUp"),
+  },
+  {
+    key: "Mod-Alt-ArrowDown",
+    run: (view) => executeMarkdownTableCommand(view, "moveRowDown"),
+  },
+  {
+    key: "Mod-Alt-ArrowLeft",
+    run: (view) => executeMarkdownTableCommand(view, "moveColumnLeft"),
+  },
+  {
+    key: "Mod-Alt-ArrowRight",
+    run: (view) => executeMarkdownTableCommand(view, "moveColumnRight"),
+  },
+  {
+    key: "Mod-k Mod-i",
+    run: (view) => executeMarkdownTableCommand(view, "insertRow"),
+  },
+  {
+    key: "Mod-k Alt-Mod-i",
+    run: (view) => executeMarkdownTableCommand(view, "deleteRow"),
+  },
+  {
+    key: "Mod-k Mod-j",
+    run: (view) => executeMarkdownTableCommand(view, "insertColumn"),
+  },
+  {
+    key: "Mod-k Alt-Mod-j",
+    run: (view) => executeMarkdownTableCommand(view, "deleteColumn"),
+  },
+];
+
+export const markdownTableExtension = (): Extension => {
+  return Prec.highest(keymap.of(markdownTableKeybindings));
+};
+
+declare module "@susisu/mte-kernel" {
+  export interface ITextEditor {
+    getCursorPosition(): Point;
+    setCursorPosition(pos: Point): void;
+    setSelectionRange(range: Range): void;
+    getLastRow(): number;
+    acceptsTableEdit(row: number): boolean;
+    getLine(row: number): string;
+    insertLine(row: number, line: string): void;
+    deleteLine(row: number): void;
+    replaceLines(startRow: number, endRow: number, lines: Array<string>): void;
+    transact(func: () => void): void;
+  }
+
+  export class Point {
+    constructor(row: number, column: number);
+    readonly row: number;
+    readonly column: number;
+  }
+
+  export class Range {
+    constructor(start: Point, end: Point);
+    readonly start: Point;
+    readonly end: Point;
+  }
+
+  export const Alignment: {
+    readonly NONE: string;
+    readonly LEFT: string;
+    readonly RIGHT: string;
+    readonly CENTER: string;
+  };
+
+  export interface TableEditorOptions {
+    leftMarginChars?: Set<string>;
+    formatType?: string;
+    minDelimiterWidth?: number;
+    defaultAlignment?: string;
+    headerAlignment?: string;
+    smartCursor?: boolean;
+  }
+
+  export function options(
+    options: TableEditorOptions
+  ): Required<TableEditorOptions>;
+
+  export class TableEditor {
+    constructor(textEditor: ITextEditor);
+    cursorIsInTable(options: Required<TableEditorOptions>): boolean;
+    format(options: Required<TableEditorOptions>): void;
+    formatAll(options: Required<TableEditorOptions>): void;
+    escape(options: Required<TableEditorOptions>): void;
+    moveFocus(
+      rowOffset: number,
+      columnOffset: number,
+      options: Required<TableEditorOptions>
+    ): void;
+    alignColumn(alignment: string, options: Required<TableEditorOptions>): void;
+    nextCell(options: Required<TableEditorOptions>): void;
+    previousCell(options: Required<TableEditorOptions>): void;
+    nextRow(options: Required<TableEditorOptions>): void;
+    insertRow(options: Required<TableEditorOptions>): void;
+    deleteRow(options: Required<TableEditorOptions>): void;
+    moveRow(offset: number, options: Required<TableEditorOptions>): void;
+    insertColumn(options: Required<TableEditorOptions>): void;
+    deleteColumn(options: Required<TableEditorOptions>): void;
+    moveColumn(offset: number, options: Required<TableEditorOptions>): void;
+  }
+}


### PR DESCRIPTION
## Summary
- integrate @susisu/mte-kernel into the Markdown CodeMirror block
- add keyboard-only Markdown table editing shortcuts and CM adapter
- keep the enhancement scoped to Markdown blocks only

https://github.com/user-attachments/assets/cef323fc-b9d7-4a03-8dfe-22c73ecc229e


## Validation
- pnpm build
- pnpm exec eslint src/editor/markdown-table.ts src/editor/CodeMirrorView.vue src/editor/markdown-edited.ts --ignore-path .gitignore

```release-note
优化 Markdown 编辑块中表格的编写体验
```